### PR TITLE
Adds possibility of disabling demos on the homepage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,4 @@ yarn-debug.log*
 yarn-error.log*
 
 bun.lock
+.vite/

--- a/src/components/DemoBlock.jsx
+++ b/src/components/DemoBlock.jsx
@@ -1,10 +1,15 @@
 import { Link } from 'react-router-dom';
 import { Container, Row, Col, Navbar } from "react-bootstrap"
 
-function DemoBlock({ title, description, picture, url }) {
+function DemoBlock({ title, description, picture, url, isDisabled = false }) {
+
     return (
         <Col xs={4}>
-            <Link to={url} title={title} className='btn btn-light border border-danger shadow rounded-0 h-100 w-100' role="button">
+            <Link to={isDisabled ? "" : url}
+                title={title}
+                className={`btn btn-light border border-danger shadow rounded-0 h-100 w-100 ${isDisabled ? 'opacity-50' : ''}`}
+                role="button"
+            >
                 <div className="px-2 pt-3 text-center">
                     <Row>
                         <Col class="d-flex">
@@ -12,7 +17,6 @@ function DemoBlock({ title, description, picture, url }) {
                             <Row class="d-flex align-middle">{description && <p className='text-break'><small>{description}</small></p>}</Row>
                         </Col>
                     </Row>
-
                 </div>
             </Link>
         </Col>

--- a/src/pages/radioButtons.jsx
+++ b/src/pages/radioButtons.jsx
@@ -1,6 +1,8 @@
 import React, { useState } from 'react';
 import 'bootstrap/dist/css/bootstrap.min.css';
 import Prompt from '../components/Prompt';
+import Demo from '../components/Demo.jsx';
+import { Container, Row, Col } from 'react-bootstrap';
 
 const RadioButtons = () => {
     const [selectedMethod, setSelectedMethod] = useState('');
@@ -22,80 +24,81 @@ const RadioButtons = () => {
     }
 
     return (
-        <main className="container mt-5 p-5">
+        <Demo>
             <Prompt title={"Radio Buttons"} instructions={"Select one of the payment methods below by checking the associated radio button."}></Prompt>
-            
-            <div className="row mt-5 justify-content-center">
-                <div className="col-4 border px-4 py-5">
-                    <h2 className="fs-3 fw-bold text-center pb-4">Select a payment method</h2>
-                    <div className="row my-5">
-                        <div className="col">
-                            <div className="card-body">
-                                {paymentMethods.map((method) => (
-                                    <div className="form-check" key={method.id}>
-                                        <input
-                                            className="form-check-input"
-                                            type="radio"
-                                            name="flexRadioDefault"
-                                            id={method.id}
-                                            disabled={isSubmitted}
-                                            checked={selectedMethod === method.label}
-                                            onChange={(e) => setSelectedMethod(method.label)}
-                                        />
-                                        <label className="form-check-label" htmlFor={method.id}>
-                                            {method.label}
-                                        </label>
-                                    </div>
-                                ))}
+            <Container>
+                <Row className="mt-5 justify-content-center">
+                    <Col xs={4} className="border px-4 py-5">
+                        <h2 className="fs-3 fw-bold text-center pb-4">Select a payment method</h2>
+                        <Row className="my-5">
+                            <Col>
+                                <div className="card-body">
+                                    {paymentMethods.map((method) => (
+                                        <div className="form-check" key={method.id}>
+                                            <input
+                                                className="form-check-input"
+                                                type="radio"
+                                                name="flexRadioDefault"
+                                                id={method.id}
+                                                disabled={isSubmitted}
+                                                checked={selectedMethod === method.label}
+                                                onChange={(e) => setSelectedMethod(method.label)}
+                                            />
+                                            <label className="form-check-label" htmlFor={method.id}>
+                                                {method.label}
+                                            </label>
+                                        </div>
+                                    ))}
+                                </div>
+                            </Col>
+                        </Row>
+
+                        <Row>
+                            <div className="d-grid gap-2 col-7 mx-auto pt-4">
+                                {!isSubmitted ? (
+                                    <button
+                                        className="btn btn-primary"
+                                        type="button"
+                                        onClick={handleNext}
+                                    >
+                                        Next
+                                    </button>
+                                ) : (
+                                    <button
+                                        className="btn btn-secondary"
+                                        disabled
+                                        role="button"
+                                        aria-disabled="true"
+                                    >
+                                        Paying with {selectedMethod}
+                                    </button>
+                                )}
+
+                                {!isSubmitted ? (
+                                    <button
+                                        className="btn btn-light"
+                                        disabled
+                                        type="button"
+                                        aria-disabled="true"
+                                    >
+                                        Cancel
+                                    </button>
+                                ) : (
+                                    <button
+                                        className="btn btn-dark"
+                                        role="button"
+                                        color='red'
+                                        onClick={handleCancel}
+                                    >
+                                        Cancel
+                                    </button>
+                                )}
                             </div>
-                        </div>
-                    </div>
-
-                    <div className="row">
-                        <div className="d-grid gap-2 col-7 mx-auto pt-4">
-                            {!isSubmitted ? (
-                                <button
-                                    className="btn btn-primary"
-                                    type="button"
-                                    onClick={handleNext}
-                                >
-                                    Next
-                                </button>
-                            ) : (
-                                <button
-                                    className="btn btn-secondary"
-                                    disabled
-                                    role="button"
-                                    aria-disabled="true"
-                                >
-                                    Paying with {selectedMethod}
-                                </button>
-                            )}
-
-                            {!isSubmitted ? (
-                                <button
-                                    className="btn btn-light"
-                                    disabled
-                                    type="button"
-                                    aria-disabled="true"
-                                >
-                                    Cancel
-                                </button>
-                            ) : (
-                                <button
-                                    className="btn btn-dark"
-                                    role="button"
-                                    color='red'
-                                    onClick={handleCancel}
-                                >
-                                    Cancel
-                                </button>
-                            )}
-                        </div>
-                    </div>
-                </div>
-            </div>
-        </main>
+                        </Row>
+                    </Col>
+                </Row>
+            </Container>
+        </Demo>
     );
 };
 

--- a/src/store/demos.jsx
+++ b/src/store/demos.jsx
@@ -4,12 +4,14 @@ const demos = [
         url: "/audioValidation",
         name: "Record and check if the audios match.",
         description: "This demo contains audio files and URLs for recording and validating if they match.",
+        isDisabled: true,
     },
     {
         title: "Browser Prompt",
         url: "/browserPrompt",
         name: "Enter values to prompts.",
         description: "This demo allows the user to interact with browser prompt forms.",
+        isDisabled: true,
     },
     {
         title: "Button Click",
@@ -28,6 +30,7 @@ const demos = [
         url: "/connectTheDots",
         name: "Click and drag in a canvas.",
         description: "This demo allows the user to draw on canvas by connecting the dots.",
+        isDisabled: true,
     },
     {
         title: "Counter",
@@ -40,12 +43,14 @@ const demos = [
         url: "/datePicker",
         name: "Choose a date on a date picker.",
         description: "This demo displays a date picker, where you can choose a date in it and see the value reflected on the field.",
+        isDisabled: true,
     },
     {
         title: "Delete Elements",
         url: "/deleteElements",
         name: "Dynamic page to delete elements.",
         description: "This demo contains different elements that can be deleted by clicking buttons, and new elements can be added.",
+        isDisabled: true,
     },
     {
         title: "Drag Item",
@@ -64,6 +69,7 @@ const demos = [
         url: "/dynamicLoginText",
         name: "Press to login with changing button text.",
         description: "This demo contains a login screen in which the affirmative button changes the text each refresh.",
+        isDisabled: true,
     },
     {
         title: "Dynamic Table",
@@ -88,12 +94,14 @@ const demos = [
         url: "/longClick",
         name: "Long click button.",
         description: "This demo contains a button that will detect a long click or a normal click depending on the setting.",
+        isDisabled: true,
     },
     {
         title: "Modal Popup",
         url: "/modalPopup",
         name: "Open a modal popup.",
         description: "This demo displays a modal popup to test the change of focus of the application.",
+        isDisabled: true,
     },
     {
         title: "Mouse Hover",
@@ -106,6 +114,7 @@ const demos = [
         url: "/nestedIframes",
         name: "Inspect and interact with nested iframes.",
         description: "In this demo, there are two levels of iframes, one inside another.",
+        isDisabled: true,
     },
     {
         title: "OCR Check",
@@ -136,6 +145,7 @@ const demos = [
         url: "/regex",
         name: "Find text using RegEx.",
         description: "This demo displays phone number patterns by country for one to search using regex.",
+        isDisabled: true,
     },
     {
         title: "Relative Position Table",
@@ -148,18 +158,21 @@ const demos = [
         url: "/rightClick",
         name: "Right click a button.",
         description: "This demo displays a button which will change its contents when right-clicked with the mouse.",
+        isDisabled: true,
     },
     {
         title: "Scroll Down",
         url: "/scrollDown",
         name: "Scroll down to find a text.",
         description: "This demo contains several texts that are widely spaced apart so that you have to scroll to find them.",
+        isDisabled: true,
     },
     {
         title: "Shadow DOM",
         url: "/shadowDom",
         name: "Different implementations of shadow DOMs.",
         description: "This demo contains different implementations of shadow DOMs.",
+        isDisabled: true,
     },
     {
         title: "Shopping Cart",
@@ -172,12 +185,14 @@ const demos = [
         url: "/similarPages",
         name: "Two pages with minor differences.",
         description: "This demo contains two pages that have differences in some element attributes and tags, but are nearly identical.",
+        isDisabled: true,
     },
     {
         title: "SVG Elements",
         url: "/svgElements",
         name: "Interact with SVG elements.",
         description: "This demo displays a number of interactive SVG elements.",
+        isDisabled: true,
     },
     {
         title: "Video Playback",


### PR DESCRIPTION
Permits that demos on the homepage can be disabled (lower opacity, non-clickable) by adding `isDisabled: true` on the `store/demos.jsx`.

All demos are enabled by default.