### PR TITLE
Configures sample files to not be parsed by vite mistakenly

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -3,4 +3,5 @@ import react from '@vitejs/plugin-react';
 
 export default defineConfig({
   plugins: [react()],
+  assetsInclude: ['**/*.csv', '**/*.doc', '**/*.docx', '**/*.odp', '**/*.ods', '**/*.odt', '**/*.ott', '**/*.pdf', '**/*.ppt', '**/*.pptx', '**/*.rtf', '**/*.txt', '**/*.xls', '**/*.xlsx'],
 });


### PR DESCRIPTION
There's a problem in which vite tries to parse the sample files like `.docx` and the others if they are imported. This configures vite to consider them assets, fixing the error.