### PR TITLE
modify: long click demo with 3 buttons

### DIFF
--- a/src/pages/longClick.jsx
+++ b/src/pages/longClick.jsx
@@ -10,12 +10,19 @@ import {
 import Layout from '../components/Layout';
 
 
+const buttons = [
+    { id: 'button1', label: 'Button 1' },
+    { id: 'button2', label: 'Button 2' },
+    { id: 'button3', label: 'Button 3' },
+];
+
 function LongClick() {
     const [isPressed, setIsPressed] = useState(false);
     const [isLongClick, setIsLongClick] = useState(false);
     const [clickPressCounter, setClickPressCounter] = useState(0);
     const [chosenClickTime, setChosenClickTime] = useState(1);
     const [startTime, setStartTime] = useState(null);
+    const [clickedButton, setClickedButton] = useState(null);
 
     useEffect(() => {
         let interval;
@@ -40,7 +47,8 @@ function LongClick() {
         return () => clearInterval(interval);
     }, [isPressed]);
 
-    const handlePressStart = () => {
+    const handlePressStart = (buttonId) => {
+        setClickedButton(buttonId);
         setIsPressed(true);
         setStartTime(Date.now());
     };
@@ -49,69 +57,72 @@ function LongClick() {
         setIsPressed(false);
     };
 
+    const getButtonLabel = (buttonId) =>
+        buttons.find((button) => button.id === buttonId)?.label ?? buttonId;
+
+    const getResultMessage = () => {
+        if (clickPressCounter <= 0) {
+            return `Press and hold a button for at least ${chosenClickTime} second${chosenClickTime === 1 ? '' : 's'}.`;
+        }
+
+        const buttonLabel = getButtonLabel(clickedButton);
+
+        if (isLongClick) {
+            return `${buttonLabel}: long click! You held for ${clickPressCounter}s.`;
+        }
+
+        return `${buttonLabel}: quick press. You held for ${clickPressCounter}s.`;
+    };
+
     return (
         <Layout
             title="Long Click"
             description="The button below will say if it was clicked by a long click or a normal click depending on the setting."
         >
             <Container className="mt-4">
-                {/* Time Selection Row */}
-                <Row className="justify-content-center mb-4">
-                    <Col xs={12} md={8} lg={6}>
-                        <Form>
-                            <Form.Group as={Row} controlId="clickTimeSelect">
-                                <Form.Label column xs={12} sm={6} md={5} className="text-sm-end mb-2 mb-sm-0">
-                                    Select long click duration (seconds):
-                                </Form.Label>
-                                <Col xs={12} sm={6} md={4}>
-                                    <Form.Select
-                                        value={chosenClickTime}
-                                        onChange={(e) => setChosenClickTime(Number(e.target.value))}
-                                        aria-label="Select long click duration"
-                                    >
-                                        {[1, 2, 3, 4, 5, 6, 7, 8, 9, 10].map((num) => (
-                                            <option key={num} value={num}>{num}</option>
-                                        ))}
-                                    </Form.Select>
-                                </Col>
-                            </Form.Group>
-                        </Form>
-                    </Col>
-                </Row>
-
-                {/* Click Button Row */}
-                <Row className="justify-content-center mb-4">
-                    <Col xs={12} sm={8} md={6} lg={4}>
-                        <div className="d-grid">
-                            <Button
-                                className={'btn-modern'}
-                                size="lg"
-                                onMouseDown={handlePressStart}
-                                onMouseUp={handlePressEnd}
-                                onMouseLeave={handlePressEnd}
-                                onTouchStart={handlePressStart}
-                                onTouchEnd={handlePressEnd}
-                            >
-                                {isPressed ? `Holding... ${clickPressCounter}s` : "Click here"}
-                            </Button>
-                        </div>
-                    </Col>
-                </Row>
-
-                {/* Result Display Row */}
                 <Row className="justify-content-center">
-                    <Col xs={12} md={8} lg={6}>
-                        <div className="d-flex flex-column flex-md-row align-items-center gap-3">
-                            <div className="fs-4 text-nowrap">Click time:</div>
+                    <Col xs={12} sm={10} md={8} lg={5} className="d-flex flex-column gap-4">
+                        <Form.Group controlId="clickTimeSelect">
+                            <Form.Label className="text-center d-block mb-2">
+                                Select long click duration (seconds):
+                            </Form.Label>
+                            <Form.Select
+                                value={chosenClickTime}
+                                onChange={(e) => setChosenClickTime(Number(e.target.value))}
+                                aria-label="Select long click duration"
+                            >
+                                {[1, 2, 3, 4, 5, 6, 7, 8, 9, 10].map((num) => (
+                                    <option key={num} value={num}>{num}</option>
+                                ))}
+                            </Form.Select>
+                        </Form.Group>
+
+                        <div className="d-grid gap-3">
+                            {buttons.map((button) => (
+                                <Button
+                                    key={button.id}
+                                    className={'btn-modern'}
+                                    size="lg"
+                                    onMouseDown={() => handlePressStart(button.id)}
+                                    onMouseUp={handlePressEnd}
+                                    onMouseLeave={handlePressEnd}
+                                    onTouchStart={() => handlePressStart(button.id)}
+                                    onTouchEnd={handlePressEnd}
+                                >
+                                    {isPressed && clickedButton === button.id
+                                        ? `Keep holding... ${clickPressCounter}s`
+                                        : button.label}
+                                </Button>
+                            ))}
+                        </div>
+
+                        <div>
+                            <div className="fs-5 text-center mb-2">Click time:</div>
                             <Alert
                                 variant={isLongClick ? 'success' : clickPressCounter > 0 ? 'danger' : 'secondary'}
-                                className="m-0 text-center flex-grow-1"
+                                className="m-0 text-center"
                             >
-                                {clickPressCounter > 0 ? (
-                                    <><strong>{clickPressCounter}s</strong> - {isLongClick ? `Long click (threshold: ${chosenClickTime}s)` : `Normal click (threshold: ${chosenClickTime}s)`}</>
-                                ) : (
-                                    `Press and hold (threshold: ${chosenClickTime}s)`
-                                )}
+                                {getResultMessage()}
                             </Alert>
                         </div>
                     </Col>


### PR DESCRIPTION
## Summary
- Cherry-pick da alteração da demo Long Click para `stg-env`
- Adiciona 3 botões com a mesma função de long click
- Resposta indica qual botão foi clicado, com mensagens mais naturais
- Layout alinhado verticalmente em coluna única

## Test plan
- [ ] Abrir `/longClick` e testar os 3 botões
- [ ] Validar long click vs quick press com diferentes durações
- [ ] Confirmar que a mensagem exibe o botão correto