### PR TITLE
Add Mock API Call Validation page (PLAYG-70)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -68,6 +68,7 @@ import IndexTesting from "./pages/indexTesting";
 import OverlappedElements from "./pages/overlappedElements";
 import ScrollPanels from "./pages/scrollPanels";
 import HorizontalVirtualRendering from "./pages/horizontalVirtualRendering";
+import MockApiPage from "./pages/mockApiPage";
 
 const DatePicker = lazy(() => import("./pages/datePicker"));
 
@@ -150,6 +151,7 @@ function App() {
         <Route path="/overlappedElements" element={<OverlappedElements />} />
         <Route path="/scrollPanels" element={<ScrollPanels />} />
         <Route path="/horizontalVirtualRendering" element={<HorizontalVirtualRendering />} />
+        <Route path="/mockApiPage" element={<MockApiPage />} />
       </Routes>
     </Router>
   );

--- a/src/pages/mockApiPage.jsx
+++ b/src/pages/mockApiPage.jsx
@@ -14,12 +14,12 @@ const POST_BODY = { source: "mock-api-playground", value: "REAL_ROUND_TRIP" };
 const scenarios = [
   {
     id: "rotatingCode",
-    title: "GET a rotating value",
+    title: "GET a stable value",
     method: "GET",
     path: "/code",
     savedValuePath: "code",
     hint:
-      "The real endpoint answers with a different code on every call. Mock it to a fixed value: when the code stops changing between requests, the response on screen is the mocked one.",
+      "The backend answers with the same code every time, so its real response is a known baseline. Mock it to any different value: the code changing is the proof that the request never reached the backend.",
   },
   {
     id: "echoGet",

--- a/src/pages/mockApiPage.jsx
+++ b/src/pages/mockApiPage.jsx
@@ -1,0 +1,246 @@
+import React, { useState } from "react";
+import Layout from "../components/Layout";
+import "../styles/homePage.css";
+import "../styles/mockApiPage.css";
+
+// Same hosted backend used by the API Validation page
+const API_URL = "https://tr-playground-api.onrender.com";
+
+// Value sent on the POST so an unmocked round trip is recognisable
+const POST_BODY = { source: "mock-api-playground", value: "REAL_ROUND_TRIP" };
+
+// Every call is fired by a button, never on page load, so a mock rule can be
+// registered before the request leaves the browser.
+const scenarios = [
+  {
+    id: "rotatingCode",
+    title: "GET a rotating value",
+    method: "GET",
+    path: "/code",
+    savedValuePath: "code",
+    hint:
+      "The real endpoint answers with a different code on every call. Mock it to a fixed value: when the code stops changing between requests, the response on screen is the mocked one.",
+  },
+  {
+    id: "echoGet",
+    title: "GET on a POST-only endpoint",
+    method: "GET",
+    path: "/echo",
+    savedValuePath: "value",
+    hint:
+      "The backend only accepts POST here, so without a mock this returns 404. Mock it with a body containing a \"value\" field and both the 200 and the value below come from the mock.",
+  },
+  {
+    id: "echoPost",
+    title: "POST with a body",
+    method: "POST",
+    path: "/echo",
+    body: POST_BODY,
+    savedValuePath: "received.value",
+    hint:
+      "Unmocked, the backend echoes the request back, so the saved value reads REAL_ROUND_TRIP. Any other value proves the mock answered instead of the backend.",
+  },
+];
+
+// Pretty-print JSON when the response is JSON, otherwise show it untouched
+const formatBody = (text) => {
+  if (!text) return "(empty body)";
+  try {
+    return JSON.stringify(JSON.parse(text), null, 2);
+  } catch {
+    return text;
+  }
+};
+
+// Pull a dotted path out of a JSON body, for the saved value line
+const extractValue = (text, path) => {
+  if (!text || !path) return null;
+  try {
+    const found = path
+      .split(".")
+      .reduce((node, key) => (node == null ? node : node[key]), JSON.parse(text));
+    if (found === null || found === undefined) return null;
+    return typeof found === "object" ? JSON.stringify(found) : String(found);
+  } catch {
+    return null;
+  }
+};
+
+const MockApiPage = () => {
+  const [results, setResults] = useState({});
+  const [pending, setPending] = useState({});
+  const [requestCount, setRequestCount] = useState(0);
+
+  const sendRequest = async (scenario) => {
+    const attempt = requestCount + 1;
+    setRequestCount(attempt);
+    setPending((current) => ({ ...current, [scenario.id]: true }));
+
+    const startedAt = performance.now();
+    const options = { method: scenario.method };
+    if (scenario.body) {
+      options.headers = { "Content-Type": "application/json" };
+      options.body = JSON.stringify(scenario.body);
+    }
+
+    try {
+      const response = await fetch(`${API_URL}${scenario.path}`, options);
+      const text = await response.text();
+      setResults((current) => ({
+        ...current,
+        [scenario.id]: {
+          attempt,
+          reached: true,
+          status: response.status,
+          statusText: response.statusText,
+          ok: response.ok,
+          elapsedMs: Math.round(performance.now() - startedAt),
+          savedValue: extractValue(text, scenario.savedValuePath),
+          body: formatBody(text),
+        },
+      }));
+    } catch (error) {
+      setResults((current) => ({
+        ...current,
+        [scenario.id]: {
+          attempt,
+          reached: false,
+          elapsedMs: Math.round(performance.now() - startedAt),
+          savedValue: null,
+          body: `Request failed: ${error.message}`,
+        },
+      }));
+    } finally {
+      setPending((current) => ({ ...current, [scenario.id]: false }));
+    }
+  };
+
+  const clearResults = () => {
+    setResults({});
+    setRequestCount(0);
+  };
+
+  return (
+    <Layout
+      title="Mock API Call Validation"
+      description={
+        <>
+          Target for the mock api call commands. Each request is sent only when
+          its button is pressed, so a mock can be registered first. The status
+          code, the saved value and the raw body are all shown, to tell a mocked
+          response apart from a real one.
+          <br />
+          <br />
+          API Base URL: {API_URL}
+          <br />
+          Note: the first real request may be slow because of cold start on
+          Render hosting.
+        </>
+      }
+    >
+      <div className="mock-toolbar">
+        <p className="mb-0">
+          Requests sent:{" "}
+          <strong id="requestCount" className="mock-counter">
+            {requestCount}
+          </strong>
+        </p>
+        <button
+          className="btn-modern btn-primary"
+          id="clearResults"
+          onClick={clearResults}
+        >
+          Clear results
+        </button>
+      </div>
+
+      <div className="api-card-grid">
+        {scenarios.map((scenario) => {
+          const result = results[scenario.id];
+          const isPending = Boolean(pending[scenario.id]);
+
+          return (
+            <div className="modern-card" id={scenario.id} key={scenario.id}>
+              <h2>{scenario.title}</h2>
+
+              <p className="mock-endpoint">
+                <span className="mock-method">{scenario.method}</span>
+                <code>{scenario.path}</code>
+              </p>
+
+              <p className="mock-hint">{scenario.hint}</p>
+
+              {scenario.body && (
+                <pre className="mock-body mock-request-body">
+                  {JSON.stringify(scenario.body, null, 2)}
+                </pre>
+              )}
+
+              <button
+                className="btn-modern btn-primary"
+                id={`send-${scenario.id}`}
+                onClick={() => sendRequest(scenario)}
+                disabled={isPending}
+              >
+                {isPending ? "Sending..." : `Send ${scenario.method}`}
+              </button>
+
+              <div className="info-block mock-result">
+                {!result ? (
+                  <p className="mock-muted mb-0" id={`empty-${scenario.id}`}>
+                    No request sent yet.
+                  </p>
+                ) : (
+                  <>
+                    <p className="mb-1">
+                      Status:{" "}
+                      <strong
+                        id={`status-${scenario.id}`}
+                        className={
+                          result.reached && result.ok
+                            ? "mock-status-ok"
+                            : "mock-status-bad"
+                        }
+                      >
+                        {result.reached
+                          ? `${result.status} ${result.statusText}`.trim()
+                          : "no response"}
+                      </strong>
+                    </p>
+                    <p className="mb-1">
+                      Saved value ({scenario.savedValuePath}):{" "}
+                      <strong
+                        id={`saved-${scenario.id}`}
+                        className="mock-saved-value"
+                      >
+                        {result.savedValue ?? "not present in response"}
+                      </strong>
+                    </p>
+                    <p className="mb-1">
+                      Elapsed:{" "}
+                      <strong id={`elapsed-${scenario.id}`}>
+                        {result.elapsedMs} ms
+                      </strong>
+                    </p>
+                    <p className="mb-1">
+                      Request number:{" "}
+                      <strong id={`attempt-${scenario.id}`}>
+                        {result.attempt}
+                      </strong>
+                    </p>
+                    <p className="mb-1">Response body:</p>
+                    <pre id={`body-${scenario.id}`} className="mock-body">
+                      {result.body}
+                    </pre>
+                  </>
+                )}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </Layout>
+  );
+};
+
+export default MockApiPage;

--- a/src/pages/mockApiPage.jsx
+++ b/src/pages/mockApiPage.jsx
@@ -182,7 +182,9 @@ const MockApiPage = () => {
                 onClick={() => sendRequest(scenario)}
                 disabled={isPending}
               >
-                {isPending ? "Sending..." : `Send ${scenario.method}`}
+                {isPending
+                  ? "Sending..."
+                  : `Send ${scenario.method} ${scenario.path}`}
               </button>
 
               <div className="info-block mock-result">

--- a/src/store/demos.jsx
+++ b/src/store/demos.jsx
@@ -39,6 +39,7 @@ import {
   ZoomIn,
   ShieldCheck,
   LayoutSidebar,
+  SignpostSplit,
 } from "react-bootstrap-icons";
 
 const iconSize = 32;
@@ -407,6 +408,12 @@ const demos = [
     path: "/overlappedElements",
     description: "Interact with elements that are covered by other elements.",
     icon: <CollectionFill size={iconSize} />,
+  },
+  {
+    title: "Mock API Call Validation",
+    path: "/mockApiPage",
+    description: "Intercept API calls with mocks and check the response used.",
+    icon: <SignpostSplit size={iconSize} />,
   },
 ];
 

--- a/src/styles/mockApiPage.css
+++ b/src/styles/mockApiPage.css
@@ -1,0 +1,80 @@
+.mock-toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  flex-wrap: wrap;
+  background-color: var(--card-bg);
+  border: 1px solid var(--border);
+  border-radius: 1rem;
+  padding: 1rem 1.5rem;
+  margin-bottom: 1.5rem;
+  color: var(--text);
+}
+
+.mock-counter {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 1.1rem;
+  color: var(--primary);
+}
+
+.mock-endpoint {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-bottom: 0.75rem;
+}
+
+.mock-method {
+  background-color: var(--primary);
+  color: #ffffff;
+  border-radius: 0.35rem;
+  padding: 0.1rem 0.5rem;
+  font-size: 0.8rem;
+  font-weight: 700;
+  letter-spacing: 0.03em;
+}
+
+.mock-hint {
+  color: var(--text-secondary);
+  font-size: 0.9rem;
+  margin-bottom: 1rem;
+}
+
+.mock-muted {
+  color: var(--text-secondary);
+}
+
+.mock-result {
+  margin-top: 1rem;
+}
+
+.mock-status-ok {
+  color: #16a34a;
+}
+
+.mock-status-bad {
+  color: var(--primary-red);
+}
+
+.mock-saved-value {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  color: var(--primary);
+}
+
+.mock-request-body {
+  margin-bottom: 1rem;
+}
+
+.mock-body {
+  background-color: var(--bg, transparent);
+  border: 1px solid var(--border);
+  border-radius: 0.5rem;
+  padding: 0.75rem;
+  margin-bottom: 0;
+  max-height: 220px;
+  overflow: auto;
+  font-size: 0.85rem;
+  white-space: pre-wrap;
+  word-break: break-word;
+}


### PR DESCRIPTION
## What

Adds a Playground page dedicated to testing the `mock api call` commands, as requested in [PLAYG-70](https://testrigor.atlassian.net/browse/PLAYG-70).

Route: `/mockApiPage` — listed on the home page as **Mock API Call Validation**.

## Why

The ticket's problem statement: the mock commands run successfully, but there is no UI that confirms the response on screen came from the mock rather than the real backend, and no easy way to tell a backend problem apart from a mocking problem.

## How it works

The page has no notion of mocking — no toggle, no fake data, no `if (mocked)` branch. It always issues a genuine request to the real hosted API, so anything different on screen can only be testRigor interception. Every call is fired by a button press, never on page load, so a mock can be registered first.

Three cards, all against endpoints that actually exist:

| Card | Button | Call | Unmocked response |
|---|---|---|---|
| GET a stable value | `Send GET /code` | `GET /code` | 200, the same code on every call |
| GET on a POST-only endpoint | `Send GET /echo` | `GET /echo` | 404 `Cannot GET /echo` |
| POST with a body | `Send POST /echo` | `POST /echo` | 200, echoes the body back |

Each unmocked response is a known, stable baseline, so any difference on screen is attributable to the mock and nothing else.

## What each card displays

Status code, a saved value extracted from a dotted path in the response, elapsed time, request number, and the raw body — all with stable ids for test locators:

`status-<cardId>` · `saved-<cardId>` · `elapsed-<cardId>` · `attempt-<cardId>` · `body-<cardId>` · `send-<cardId>`

Card ids are `rotatingCode`, `echoGet` and `echoPost`. Plus a global `requestCount` and a `clearResults` button.

Every button label is unique, so a test step can identify a button by its visible text without needing an ordinal.

## Example test steps

Because the real `GET /code` response is stable, it can be fetched once and used as the "this came from the backend" marker:

```
call api get "https://tr-playground-api.onrender.com/code" and get "$.code" and save it as "realCode"
mock api call get "https://tr-playground-api.onrender.com/code" returning body "{\"code\":\"MOCKED_CODE_123\",\"timestamp\":0}" with http status code 200
click "Send GET /code"
check that page contains "MOCKED_CODE_123"
```

The full set of seven scenarios lives in the `mock api` test case of the `testRigorPlayground` suite.

## Coverage of the ticket

- [x] GET to `/echo`
- [x] POST to `/echo`
- [x] Display the response body
- [x] Display the HTTP status code
- [x] `mock api call get` / `mock api call post` — same endpoint, both methods, so the rule can be checked for method matching
- [x] Mocked response bodies
- [x] Mocked saved values — dedicated field with a stable id
- [x] Mocked HTTP status codes

## Note for the reporter

The ticket asks for a GET against "the existing `/echo` endpoint", but the backend is POST-only there — `GET /echo` returns a 404 HTML page. It is implemented anyway, since a real endpoint returning a known 404 is a legitimate baseline: any 200 shown on that card can only have come from a mock. If a real 200 on `GET /echo` is wanted, that needs a handler added to the API service, which lives outside this repository.

## Testing

`npm run build` passes on top of `stg-env`. All three endpoints were probed directly against the live API: `GET /code` returns 200 with a stable code (verified unchanged across eight consecutive calls), `GET /echo` returns 404, `POST /echo` echoes the body.

🤖 Generated with [Claude Code](https://claude.com/claude-code)