### PR TITLE
Add Opacity Validation page

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -66,6 +66,7 @@ import Recaptcha from "./pages/recaptcha";
 import ScrollPanels from "./pages/scrollPanels";
 import HorizontalVirtualRendering from "./pages/horizontalVirtualRendering";
 import MockApiPage from "./pages/mockApiPage";
+import OpacityValidation from "./pages/opacityValidation";
 
 function App() {
   return (
@@ -144,6 +145,7 @@ function App() {
         <Route path="/scrollPanels" element={<ScrollPanels />} />
         <Route path="/horizontalVirtualRendering" element={<HorizontalVirtualRendering />} />
         <Route path="/mockApiPage" element={<MockApiPage />} />
+        <Route path="/opacityValidation" element={<OpacityValidation />} />
       </Routes>
     </Router>
   );

--- a/src/pages/opacityValidation.jsx
+++ b/src/pages/opacityValidation.jsx
@@ -1,0 +1,64 @@
+import React, { useState } from "react";
+import Layout from "../components/Layout";
+import "../styles/opacityValidation.css";
+
+const opacityLevels = [
+  { id: "opacity-100", opacity: 1, label: "Opacity 100" },
+  { id: "opacity-50", opacity: 0.5, label: "Opacity 50" },
+  { id: "opacity-10", opacity: 0.1, label: "Opacity 10" },
+  { id: "opacity-01", opacity: 0.01, label: "Opacity 1" },
+  { id: "opacity-0", opacity: 0, label: "Opacity 0" },
+];
+
+const OpacityValidation = () => {
+  const [clickedLevel, setClickedLevel] = useState(null);
+
+  return (
+    <Layout
+      title="Opacity Validation"
+      description="Interact with elements rendered at different opacity levels."
+    >
+      <div className="opacity-section">
+        <h2 className="opacity-section-title">Opacity Levels</h2>
+        <p className="opacity-section-description">
+          Every card below is present in the DOM and clickable. The only
+          difference between them is the <code>opacity</code> value applied to
+          the card.
+        </p>
+
+        <div className="opacity-levels-grid">
+          {opacityLevels.map((level) => (
+            <div
+              key={level.id}
+              id={`${level.id}-card`}
+              className="opacity-card"
+              style={{ opacity: level.opacity }}
+            >
+              <span className="opacity-card-value">
+                opacity: {level.opacity}
+              </span>
+              <p className="opacity-card-text">{level.label} text</p>
+              <button
+                id={`${level.id}-button`}
+                className="btn-modern btn-primary"
+                onClick={() => setClickedLevel(level.label)}
+              >
+                {level.label} button
+              </button>
+            </div>
+          ))}
+        </div>
+
+        <div className="opacity-feedback-area">
+          {clickedLevel && (
+            <div className="opacity-feedback success">
+              ✓ You clicked the <strong>{clickedLevel} button</strong>!
+            </div>
+          )}
+        </div>
+      </div>
+    </Layout>
+  );
+};
+
+export default OpacityValidation;

--- a/src/store/demos.jsx
+++ b/src/store/demos.jsx
@@ -40,6 +40,7 @@ import {
   ShieldCheck,
   LayoutSidebar,
   SignpostSplit,
+  DropletHalf,
 } from "react-bootstrap-icons";
 
 const iconSize = 32;
@@ -390,6 +391,12 @@ const demos = [
     path: "/mockApiPage",
     description: "Intercept API calls with mocks and check the response used.",
     icon: <SignpostSplit size={iconSize} />,
+  },
+  {
+    title: "Opacity Validation",
+    path: "/opacityValidation",
+    description: "Interact with elements at different opacity levels.",
+    icon: <DropletHalf size={iconSize} />,
   },
 ];
 

--- a/src/styles/opacityValidation.css
+++ b/src/styles/opacityValidation.css
@@ -1,0 +1,81 @@
+/* Opacity Validation Demo */
+.opacity-section {
+  background-color: var(--card-bg);
+  border: 1px solid var(--border);
+  border-radius: 1rem;
+  padding: 2rem;
+  margin-bottom: 2rem;
+  transition: background-color 0.3s ease;
+}
+
+.opacity-section-title {
+  font-size: 1.25rem;
+  font-weight: 600;
+  color: var(--text);
+  margin-bottom: 0.25rem;
+}
+
+.opacity-section-description {
+  font-size: 0.875rem;
+  color: var(--text-secondary);
+  margin-bottom: 1.5rem;
+}
+
+.opacity-levels-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 1rem;
+}
+
+.opacity-card {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 1.25rem 1rem;
+  border: 1px solid var(--border);
+  border-radius: 0.75rem;
+  background-color: var(--card-hover);
+}
+
+/* The shared .btn-modern.btn-primary rule carries opacity: 0.8, which would
+   multiply with the card opacity. Pinned to 1 here so the effective opacity of
+   each button matches the value its card is labelled with. */
+.opacity-card .btn-modern.btn-primary {
+  opacity: 1;
+}
+
+.opacity-card-value {
+  font-family: monospace;
+  font-size: 0.8rem;
+  color: var(--text-secondary);
+}
+
+.opacity-card-text {
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--text);
+  margin: 0;
+  text-align: center;
+}
+
+.opacity-feedback-area {
+  margin-top: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.opacity-feedback {
+  padding: 0.75rem 1rem;
+  border-radius: 0.5rem;
+  font-weight: 500;
+  font-size: 0.9rem;
+  animation: fadeIn 0.3s ease-out;
+}
+
+.opacity-feedback.success {
+  background-color: rgba(34, 197, 94, 0.1);
+  border: 1px solid rgba(34, 197, 94, 0.25);
+  color: rgb(34, 197, 94);
+}


### PR DESCRIPTION
Closes [PLAYG-74](https://testrigor.atlassian.net/browse/PLAYG-74).

Cherry-pick of the single Opacity Validation commit from `stg-env` (`d2b1e4b`), promoting only this change to production. No other divergence between `stg-env` and `main` is carried over.

Adds a demo page for validating the **Use opacity to determine visibility of web elements** setting.

## Page

`Opacity Validation` at `/opacityValidation`, listed on the home grid with the `DropletHalf` icon.

Five cards are rendered side by side, identical except for the `opacity` value applied to the card. Each carries a distinct text and a clickable button, and all of them stay in the DOM and remain clickable regardless of opacity — so the same test yields opposite results depending on the setting.

| Card | Text | Button id |
|---|---|---|
| `opacity: 1` | Opacity 100 text | `opacity-100-button` |
| `opacity: 0.5` | Opacity 50 text | `opacity-50-button` |
| `opacity: 0.1` | Opacity 10 text | `opacity-10-button` |
| `opacity: 0.01` | Opacity 1 text | `opacity-01-button` |
| `opacity: 0` | Opacity 0 text | `opacity-0-button` |

Clicking any button — including the fully transparent one — shows a feedback message naming the level.

The shared `.btn-modern.btn-primary` rule carries `opacity: 0.8`, which would multiply with the card opacity and leave each button at a different effective value than its label. A selector scoped to `.opacity-card` pins it to `1`, so the labelled value holds for everything inside the card, text and button alike. Buttons on other pages are unaffected.

## Example test steps

```
// with the setting enabled
check that page contains text "Opacity 100 text"
check that page does not contain text "Opacity 0 text"

// with the setting disabled
check that page contains text "Opacity 0 text"

// interaction is independent of opacity
click "Opacity 0 button"
check that page contains text "You clicked the Opacity 0 button!"
```

## Verification

Already validated on staging via [#224](https://github.com/thiagonunes11/testRigorPlayground/pull/224): the CI/CD (PLAYG-STG) suite ran green against https://stg-tr-playground.netlify.app/ with 88/88 test cases passing ([run](https://app.testrigor.com/test-suites/A8T8G9NN24mJ9zbe6/runs/zrYQ74yyMTmp5T22K)).

On this branch, the two new files are byte-identical to their `stg-env` counterparts, the cherry-pick applied with no conflicts, and `npm run build` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)