### PR TITLE
Fix headless and incognito detection on the OS & Browser page

### DIFF
--- a/src/pages/osBrowser.jsx
+++ b/src/pages/osBrowser.jsx
@@ -1,160 +1,73 @@
 import React, { useMemo, useEffect, useState } from "react";
-import { Container, Row, Col, Button, OverlayTrigger, Tooltip } from "react-bootstrap";
+import { Container, Row, Col, OverlayTrigger, Tooltip } from "react-bootstrap";
 import { InfoCircle } from "react-bootstrap-icons";
 import Layout from "../components/Layout";
+import {
+  CHROMIUM_PRIVATE_QUOTA_MAX,
+  collectBrowserInfo,
+  collectHeadlessSignals,
+  detectAutomation,
+  detectBrowserFamily,
+  detectPrivateMode,
+  formatBytes,
+  getOSInfo,
+  readStorageQuota,
+  verdictLabel,
+} from "../utils/environmentDetection";
 import "../styles/homePage.css";
 
-const collectBrowserInfo = () => {
-  const ua = navigator.userAgent || "";
-  const vendor = navigator.vendor || "";
-  const platform = navigator.platform || "";
-  const languages = navigator.languages || [];
-  const language = navigator.language || "";
-
-  let uaData = null;
-  try {
-    if (navigator.userAgentData) {
-      uaData = {
-        brands: navigator.userAgentData.brands || [],
-        mobile: navigator.userAgentData.mobile,
-        platform: navigator.userAgentData.platform,
-      };
-    }
-  } catch (_) { }
-
-  return {
-    ua,
-    vendor,
-    platform,
-    language,
-    languages,
-    uaData,
-  };
+const CONFIDENCE_LABELS = {
+  high: "High",
+  medium: "Medium",
+  low: "Low",
+  none: "None",
 };
 
-const detectBrowserFamily = () => {
-  const ua = navigator.userAgent || "";
-  const vendor = navigator.vendor || "";
-
-  // Firefox
-  if (/Firefox\/\d+/i.test(ua)) {
-    return "Firefox";
-  }
-
-  // Edge (Chromium)
-  if (/Edg\//i.test(ua)) {
-    return "Edge (Chromium)";
-  }
-
-  // Chrome / Chromium-based (Chrome, Brave, Opera, etc.)
-  if (/Chrome\/\d+/i.test(ua) && /Google Inc/i.test(vendor)) {
-    return "Chrome (Chromium)";
-  }
-
-  // Safari
-  if (/Safari\/\d+/i.test(ua) && !/Chrome\/\d+/i.test(ua)) {
-    return "Safari / WebKit";
-  }
-
-  // Fallback
-  if (/Chrome|Chromium/i.test(ua)) {
-    return "Chromium-based (other)";
-  }
-
-  return "Unknown";
-};
-
-const getOSInfo = () => {
-  const ua = navigator.userAgent;
-  const platform =
-    navigator.userAgentData?.platform ||
-    /(Windows|Macintosh|Linux|Android|iPhone|iPad|iPod)/.exec(ua)?.[0] ||
-    "Unknown";
-
-  let name = "Unknown";
-  if (/Windows NT 10\.0/.test(ua)) name = "Windows 10/11";
-  else if (/Windows NT 6\.3/.test(ua)) name = "Windows 8.1";
-  else if (/Windows NT 6\.2/.test(ua)) name = "Windows 8";
-  else if (/Windows NT 6\.1/.test(ua)) name = "Windows 7";
-  else if (/Mac OS X/.test(ua)) name = "macOS";
-  else if (/Android/.test(ua)) name = "Android";
-  else if (/(iPhone|iPad|iPod)/.test(ua)) name = "iOS";
-  else if (/Linux/.test(ua)) name = "Linux";
-
-  // Prefer platformVersion (UA-CH) over UA parsing
-  const uaChVersion = navigator.userAgentData?.platformVersion; // ex: "14.0.0"
-  const uaParsedVersion = (
-    ua.match(/Android\s([\d._]+)/)?.[1] || ua.match(/OS\s([\d_]+)/)?.[1]
-  )?.replace(/_/g, ".");
-
-  const version = uaChVersion || uaParsedVersion || "Unknown";
-  return { name, platform, version };
-};
-
-const detectHeadless = () => {
-  try {
-    const ua = navigator.userAgent || "";
-    const webdriver = navigator.webdriver === true;
-    const uaHeadless = /HeadlessChrome|HeadlessFirefox/i.test(ua);
-    return webdriver || uaHeadless; // boolean
-  } catch {
-    return false;
-  }
-};
+const VerdictCard = ({ title, testId, verdict, tooltip }) => (
+  <div className="modern-card h-100">
+    <div className="position-relative mb-2">
+      <h5 className="fw-bold mb-0 text-center">{title}</h5>
+      {tooltip && (
+        <OverlayTrigger
+          placement="left"
+          overlay={<Tooltip id={`${testId}-tooltip`}>{tooltip}</Tooltip>}
+        >
+          <InfoCircle
+            className="text-muted position-absolute"
+            size={18}
+            style={{ right: 0, top: "50%", transform: "translateY(-50%)", cursor: "pointer" }}
+          />
+        </OverlayTrigger>
+      )}
+    </div>
+    <p className="mb-1">
+      Status: <span data-testid={`${testId}-status`}>{verdictLabel(verdict)}</span>
+    </p>
+    <p className="text-muted small mb-1">
+      Confidence:{" "}
+      <span data-testid={`${testId}-confidence`}>
+        {verdict ? CONFIDENCE_LABELS[verdict.confidence] ?? verdict.confidence : "—"}
+      </span>
+    </p>
+    <p className="text-muted small mb-0" data-testid={`${testId}-reason`}>
+      {verdict ? verdict.reason : "Running detection…"}
+    </p>
+  </div>
+);
 
 const OsBrowser = () => {
-  const [isHeadless, setIsHeadless] = useState(null);
-  const [isIncognito, setIsIncognito] = useState(null);
+  const [headless, setHeadless] = useState(null);
+  const [headlessSignals, setHeadlessSignals] = useState([]);
+  const [incognito, setIncognito] = useState(null);
 
   const [browserFamily, setBrowserFamily] = useState("Unknown");
   const [uaSummary, setUaSummary] = useState({});
   const [quota, setQuota] = useState(null);
 
-  const [wfsSupported, setWfsSupported] = useState(false);
-  const [wfsResult, setWfsResult] = useState("not_called"); // "success" | "error" | "not_called"
-  const [wfsErrorName, setWfsErrorName] = useState("");
-
+  const automation = useMemo(detectAutomation, []);
   const os = useMemo(getOSInfo, []);
   const [deviceModel, setDeviceModel] = useState("Unavailable");
-  const [platformVersion, setPlatformVersion] = useState(
-    os.version || "Unknown"
-  );
-
-
-  const testWebkitRequestFileSystem = async () => {
-    try {
-      const w = window;
-      if (!w.webkitRequestFileSystem) {
-        setWfsSupported(false);
-        setWfsResult("not_supported");
-        setWfsErrorName("");
-        return;
-      }
-
-      setWfsSupported(true);
-
-      await new Promise((resolve) => {
-        w.webkitRequestFileSystem(
-          w.TEMPORARY,
-          1024,
-          () => {
-            setWfsResult("success");
-            setWfsErrorName("");
-            resolve();
-          },
-          (err) => {
-            setWfsResult("error");
-            setWfsErrorName((err && err.name) || "");
-            resolve();
-          }
-        );
-      });
-    } catch (e) {
-      setWfsSupported(true);
-      setWfsResult("error");
-      setWfsErrorName(e.name || String(e));
-    }
-  };
+  const [platformVersion, setPlatformVersion] = useState(os.version || "Unknown");
 
   useEffect(() => {
     // Try high-entropy UA-CH for model and platformVersion on supporting browsers (Chromium on Android)
@@ -171,32 +84,32 @@ const OsBrowser = () => {
   }, [os.version]);
 
   useEffect(() => {
-    const fam = detectBrowserFamily();
-    setBrowserFamily(fam);
-    const info = collectBrowserInfo();
-    setUaSummary(info);
-    (async () => {
-      try {
-        if (navigator.storage && navigator.storage.estimate) {
-          const result = await navigator.storage.estimate();
-          setQuota(result.quota);
+    let active = true;
 
-        }
-      } catch (err) {
-        setQuota(null);
-      }
-    })();
+    const family = detectBrowserFamily();
+    setBrowserFamily(family);
+    setUaSummary(collectBrowserInfo());
+
     (async () => {
-      await testWebkitRequestFileSystem();
+      // The quota is read before any verdict is published, so the cards never
+      // show a confident answer derived from a value that is not in yet.
+      const measuredQuota = await readStorageQuota();
+      if (!active) return;
+      setQuota(measuredQuota);
+      setIncognito(detectPrivateMode(family, measuredQuota));
     })();
-    const head = detectHeadless();
-    setIsHeadless(head);
+
+    (async () => {
+      const { signals, verdict } = await collectHeadlessSignals();
+      if (!active) return;
+      setHeadlessSignals(signals);
+      setHeadless(verdict);
+    })();
+
+    return () => {
+      active = false;
+    };
   }, []);
-
-  useEffect(() => {
-    browserFamily === "Chrome (Chromium)" && quota !== null && quota < 100000000000 ? setIsIncognito(true) : setIsIncognito(false);
-  }, [quota]);
-
 
   return (
     <Layout
@@ -204,9 +117,9 @@ const OsBrowser = () => {
       description="Detect the operating system and browser details from the current client."
     >
       <Container>
-        <Row>
-          <Col>
-            <div className="modern-card">
+        <Row className="g-3">
+          <Col md={6}>
+            <div className="modern-card h-100">
               <h2>Operating System</h2>
               <div className="info-block">
                 <p>
@@ -224,11 +137,9 @@ const OsBrowser = () => {
               </div>
             </div>
           </Col>
-          <Col>
-            <div className="modern-card">
-              <h5 className="fw-bold mb-2">
-                Browser Information
-              </h5>
+          <Col md={6}>
+            <div className="modern-card h-100">
+              <h5 className="fw-bold mb-2">Browser Information</h5>
 
               <p>
                 <strong>Browser Family:</strong> {browserFamily}
@@ -255,58 +166,84 @@ const OsBrowser = () => {
               </p>
 
               <p className="text-muted small mb-1">
-                <strong>Quota:</strong>
-                {quota}
+                <strong>Storage quota:</strong>{" "}
+                <span data-testid="storage-quota">
+                  {quota === null ? "Unavailable" : formatBytes(quota)}
+                </span>
               </p>
-              <p>
-                <strong>webkitRequestFileSystem supported:</strong>{" "}
-                {wfsSupported ? "yes" : "no"}
-              </p>
-              <p>
-                <strong>webkitRequestFileSystem result:</strong> {wfsResult}
-              </p>
-              <p>
-                <strong>webkitRequestFileSystem error:</strong>{" "}
-                {wfsErrorName || "(none)"}{" "}
+
+              <p className="text-muted small mb-0">
+                <strong>Storage quota (bytes):</strong>{" "}
+                <span data-testid="storage-quota-bytes">{quota === null ? "0" : quota}</span>
               </p>
             </div>
           </Col>
-          <Col>
-            <div className="modern-card">
-              <h5 className="fw-bold mb-2">Headless Mode</h5>
-              <p className="text-muted mb-0">
-                Status:{" "}
-                {isHeadless === null ? "Detecting…" : isHeadless ? "On" : "Off"}
-              </p>
-            </div>
+        </Row>
+
+        <Row className="g-3 mt-1">
+          <Col md={4}>
+            <VerdictCard
+              title="Automation (WebDriver)"
+              testId="automation"
+              verdict={automation.verdict}
+              tooltip="Reads navigator.webdriver. It reports automation, not headless: a visible browser driven by Selenium or testRigor sets it too."
+            />
           </Col>
+          <Col md={4}>
+            <VerdictCard
+              title="Headless Mode"
+              testId="headless"
+              verdict={headless}
+              tooltip="A headless user agent token is decisive. Otherwise the verdict comes from how many of the signals below matched, since none of them is conclusive on its own."
+            />
+          </Col>
+          <Col md={4}>
+            <VerdictCard
+              title="Incognito Mode"
+              testId="incognito"
+              verdict={incognito}
+              tooltip={`On Chromium, private windows get a fixed storage quota (2 GiB) while normal windows get a disk-derived one capped at 10 GiB. Quotas above ${formatBytes(
+                CHROMIUM_PRIVATE_QUOTA_MAX
+              )} rule private mode out. On Firefox the check is Service Worker availability; Safari exposes no reliable signal.`}
+            />
+          </Col>
+        </Row>
+
+        <Row className="g-3 mt-1">
           <Col>
             <div className="modern-card">
-              <div className="position-relative mb-2">
-                <h5 className="fw-bold mb-0 text-center">Incognito Mode</h5>
-                <OverlayTrigger
-                  placement="left"
-                  overlay={
-                    <Tooltip id="incognito-info-tooltip">
-                      For Chrome, incognito mode is being determined with the size of quota offered by the browser
-                    </Tooltip>
-                  }
-                >
-                  <InfoCircle
-                    className="text-muted position-absolute"
-                    size={18}
-                    style={{ right: 0, top: "50%", transform: "translateY(-50%)", cursor: "pointer" }}
-                  />
-                </OverlayTrigger>
-              </div>
-              <p className="text-muted mb-0">
-                Status:{" "}
-                {isIncognito === null
-                  ? "Detecting…"
-                  : isIncognito
-                    ? "On"
-                    : "Off"}
+              <h5 className="fw-bold mb-2">Headless Signals</h5>
+              <p className="text-muted small">
+                Raw values behind the headless verdict. Each signal is a hint on its own.
               </p>
+              <table className="table table-sm align-middle mb-0">
+                <thead>
+                  <tr>
+                    <th scope="col">Signal</th>
+                    <th scope="col">Matched</th>
+                    <th scope="col">Value</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {headlessSignals.length === 0 ? (
+                    <tr>
+                      <td colSpan={3} className="text-muted">
+                        Collecting signals…
+                      </td>
+                    </tr>
+                  ) : (
+                    headlessSignals.map((signal) => (
+                      <tr key={signal.id} data-testid={`headless-signal-${signal.id}`}>
+                        <td>{signal.label}</td>
+                        <td data-testid={`headless-signal-${signal.id}-matched`}>
+                          {signal.matched ? "Yes" : "No"}
+                        </td>
+                        <td className="text-muted small text-break">{signal.value}</td>
+                      </tr>
+                    ))
+                  )}
+                </tbody>
+              </table>
             </div>
           </Col>
         </Row>

--- a/src/utils/environmentDetection.js
+++ b/src/utils/environmentDetection.js
@@ -1,0 +1,440 @@
+/**
+ * Browser environment detection helpers used by the OS & Browser demo page.
+ *
+ * Headless and private (incognito) browsing are not directly exposed by any web
+ * API, so every check below is a heuristic. Each detector returns a verdict
+ * object instead of a boolean:
+ *
+ *   { state, confidence, reason }
+ *
+ *   state:      "on" | "likely-on" | "off" | "inconclusive" | "unknown" | "unsupported"
+ *   confidence: "high" | "medium" | "low" | "none"
+ *   reason:     human readable explanation of what drove the verdict
+ */
+
+const GiB = 1024 ** 3;
+
+/**
+ * Chromium hands out a fixed storage quota in private windows and a
+ * disk-derived one (capped) in normal windows. Measured on Chrome 151 / macOS:
+ *
+ *   normal window    -> exactly 10 GiB (10737418240)
+ *   incognito window -> exactly  2 GiB (2147483648)
+ *
+ * Anything above this ceiling is normal-mode territory.
+ */
+export const CHROMIUM_PRIVATE_QUOTA_MAX = 2.5 * GiB;
+
+/** Default window size of a headless Chromium instance. */
+const HEADLESS_DEFAULT_SCREEN = { width: 800, height: 600 };
+
+const SOFTWARE_RENDERER = /SwiftShader|llvmpipe|Mesa OffScreen|Software|Microsoft Basic Render/i;
+
+export const formatBytes = (bytes) => {
+  if (typeof bytes !== "number" || Number.isNaN(bytes)) return "Unknown";
+  const units = ["B", "KiB", "MiB", "GiB", "TiB"];
+  let value = bytes;
+  let unit = 0;
+  while (value >= 1024 && unit < units.length - 1) {
+    value /= 1024;
+    unit += 1;
+  }
+  const rounded = value >= 100 || Number.isInteger(value) ? Math.round(value) : value.toFixed(2);
+  return `${rounded} ${units[unit]}`;
+};
+
+/**
+ * Private-mode quotas are fixed powers of two (120 MiB, 1 GiB, 2 GiB), while a
+ * normal-mode quota is a share of the free disk space and virtually never lands
+ * on an exact power of two. This is what separates a real incognito window from
+ * a normal window on an almost full disk.
+ */
+const isPowerOfTwo = (n) =>
+  typeof n === "number" && n > 0 && Number.isInteger(Math.log2(n));
+
+/**
+ * Some of these APIs never settle in a headless browser (enumerateDevices was
+ * measured hanging on Chrome 151 headless), so a reader that does not answer in
+ * time falls back instead of stalling the whole verdict.
+ */
+const SIGNAL_TIMEOUT_MS = 1500;
+
+const withTimeout = (promise, fallback) =>
+  Promise.race([
+    promise,
+    new Promise((resolve) => setTimeout(() => resolve(fallback), SIGNAL_TIMEOUT_MS)),
+  ]);
+
+export const collectBrowserInfo = () => {
+  const ua = navigator.userAgent || "";
+  const vendor = navigator.vendor || "";
+  const platform = navigator.platform || "";
+  const languages = navigator.languages || [];
+  const language = navigator.language || "";
+
+  let uaData = null;
+  try {
+    if (navigator.userAgentData) {
+      uaData = {
+        brands: navigator.userAgentData.brands || [],
+        mobile: navigator.userAgentData.mobile,
+        platform: navigator.userAgentData.platform,
+      };
+    }
+  } catch (_) { }
+
+  return {
+    ua,
+    vendor,
+    platform,
+    language,
+    languages,
+    uaData,
+  };
+};
+
+export const detectBrowserFamily = () => {
+  const ua = navigator.userAgent || "";
+  const vendor = navigator.vendor || "";
+
+  // Firefox
+  if (/Firefox\/\d+/i.test(ua)) {
+    return "Firefox";
+  }
+
+  // Edge (Chromium)
+  if (/Edg\//i.test(ua)) {
+    return "Edge (Chromium)";
+  }
+
+  // Chrome / Chromium-based (Chrome, Brave, Opera, etc.)
+  if (/Chrome\/\d+/i.test(ua) && /Google Inc/i.test(vendor)) {
+    return "Chrome (Chromium)";
+  }
+
+  // Safari
+  if (/Safari\/\d+/i.test(ua) && !/Chrome\/\d+/i.test(ua)) {
+    return "Safari / WebKit";
+  }
+
+  // Fallback
+  if (/Chrome|Chromium/i.test(ua)) {
+    return "Chromium-based (other)";
+  }
+
+  return "Unknown";
+};
+
+/** Every Chromium flavour shares the same storage quota behaviour. */
+export const isChromiumFamily = (family) =>
+  /Chrome|Chromium|Edge|Opera|Brave/i.test(family || "");
+
+export const getOSInfo = () => {
+  const ua = navigator.userAgent;
+  const platform =
+    navigator.userAgentData?.platform ||
+    /(Windows|Macintosh|Linux|Android|iPhone|iPad|iPod)/.exec(ua)?.[0] ||
+    "Unknown";
+
+  let name = "Unknown";
+  if (/Windows NT 10\.0/.test(ua)) name = "Windows 10/11";
+  else if (/Windows NT 6\.3/.test(ua)) name = "Windows 8.1";
+  else if (/Windows NT 6\.2/.test(ua)) name = "Windows 8";
+  else if (/Windows NT 6\.1/.test(ua)) name = "Windows 7";
+  else if (/Mac OS X/.test(ua)) name = "macOS";
+  else if (/Android/.test(ua)) name = "Android";
+  else if (/(iPhone|iPad|iPod)/.test(ua)) name = "iOS";
+  else if (/Linux/.test(ua)) name = "Linux";
+
+  // Prefer platformVersion (UA-CH) over UA parsing
+  const uaChVersion = navigator.userAgentData?.platformVersion; // ex: "14.0.0"
+  const uaParsedVersion = (
+    ua.match(/Android\s([\d._]+)/)?.[1] || ua.match(/OS\s([\d_]+)/)?.[1]
+  )?.replace(/_/g, ".");
+
+  const version = uaChVersion || uaParsedVersion || "Unknown";
+  return { name, platform, version };
+};
+
+/**
+ * Storage quota offered to this origin, in bytes, or null when unavailable.
+ * navigator.webkitTemporaryStorage is the fallback for older Chromium builds
+ * that predate StorageManager.estimate().
+ */
+export const readStorageQuota = async () => {
+  try {
+    if (navigator.storage?.estimate) {
+      const { quota } = (await withTimeout(navigator.storage.estimate(), {})) ?? {};
+      if (typeof quota === "number") return quota;
+    }
+  } catch (_) { }
+
+  try {
+    if (navigator.webkitTemporaryStorage?.queryUsageAndQuota) {
+      return await withTimeout(
+        new Promise((resolve) => {
+          navigator.webkitTemporaryStorage.queryUsageAndQuota(
+            (_usage, quota) => resolve(typeof quota === "number" ? quota : null),
+            () => resolve(null)
+          );
+        }),
+        null
+      );
+    }
+  } catch (_) { }
+
+  return null;
+};
+
+/**
+ * Private / incognito browsing verdict.
+ *
+ * Chromium: compares the storage quota against the fixed private-mode ceiling.
+ * Firefox:  Service Workers are unavailable in private windows.
+ * Safari:    no reliable signal on current versions, reported as unsupported.
+ */
+export const detectPrivateMode = (family, quota) => {
+  if (isChromiumFamily(family)) {
+    if (quota === null || quota === undefined) {
+      return {
+        state: "unknown",
+        confidence: "none",
+        reason: "Storage quota is unavailable, so no verdict can be produced.",
+      };
+    }
+
+    if (quota > CHROMIUM_PRIVATE_QUOTA_MAX) {
+      return {
+        state: "off",
+        confidence: "high",
+        reason: `Quota of ${formatBytes(quota)} is above the ${formatBytes(
+          CHROMIUM_PRIVATE_QUOTA_MAX
+        )} private-mode ceiling.`,
+      };
+    }
+
+    if (isPowerOfTwo(quota)) {
+      return {
+        state: "on",
+        confidence: "high",
+        reason: `Quota is exactly ${formatBytes(
+          quota
+        )}, the fixed allowance handed out to private windows.`,
+      };
+    }
+
+    return {
+      state: "likely-on",
+      confidence: "low",
+      reason: `Quota of ${formatBytes(
+        quota
+      )} is below the private-mode ceiling but is not a fixed allowance, so an almost full disk cannot be ruled out.`,
+    };
+  }
+
+  if (/Firefox/i.test(family)) {
+    // navigator.serviceWorker is also missing on insecure origins, which would
+    // otherwise read as a false positive.
+    if (!window.isSecureContext) {
+      return {
+        state: "unknown",
+        confidence: "none",
+        reason:
+          "The Firefox check relies on Service Worker availability, which is also blocked on insecure origins.",
+      };
+    }
+
+    if (navigator.serviceWorker === undefined) {
+      return {
+        state: "on",
+        confidence: "medium",
+        reason: "Service Workers are unavailable, as they are in Firefox private windows.",
+      };
+    }
+
+    return {
+      state: "off",
+      confidence: "medium",
+      reason: "Service Workers are available, which private Firefox windows do not allow.",
+    };
+  }
+
+  return {
+    state: "unsupported",
+    confidence: "none",
+    reason: `No reliable private-mode signal exists for ${family || "this browser"}.`,
+  };
+};
+
+const readWebGlRenderer = () => {
+  try {
+    const canvas = document.createElement("canvas");
+    const gl = canvas.getContext("webgl") || canvas.getContext("experimental-webgl");
+    if (!gl) return "";
+    const debugInfo = gl.getExtension("WEBGL_debug_renderer_info");
+    return debugInfo
+      ? gl.getParameter(debugInfo.UNMASKED_RENDERER_WEBGL)
+      : gl.getParameter(gl.RENDERER);
+  } catch (_) {
+    return "";
+  }
+};
+
+const countMediaDevices = async () => {
+  try {
+    if (!navigator.mediaDevices?.enumerateDevices) return null;
+    const devices = await navigator.mediaDevices.enumerateDevices();
+    return devices.length;
+  } catch (_) {
+    return null;
+  }
+};
+
+const readNotificationPermissionState = async () => {
+  try {
+    if (!navigator.permissions?.query) return null;
+    const status = await navigator.permissions.query({ name: "notifications" });
+    return status.state;
+  } catch (_) {
+    return null;
+  }
+};
+
+/**
+ * Individual headless signals, each with the raw value it was derived from.
+ * No single signal is decisive: the user agent token is authoritative when
+ * present but automation tools routinely override the user agent, while the
+ * remaining signals fire on containerised Linux runners and stay silent on a
+ * headless macOS or Windows browser.
+ */
+export const collectHeadlessSignals = async () => {
+  const ua = navigator.userAgent || "";
+  const renderer = readWebGlRenderer();
+  const [mediaDeviceCount, notificationPermissionState] = await Promise.all([
+    withTimeout(countMediaDevices(), null),
+    withTimeout(readNotificationPermissionState(), null),
+  ]);
+  const notificationPermission =
+    typeof Notification !== "undefined" ? Notification.permission : null;
+
+  const signals = [
+    {
+      id: "uaHeadlessToken",
+      label: "User agent reports a headless build",
+      matched: /Headless/i.test(ua),
+      value: ua,
+    },
+    {
+      id: "missingWindowChrome",
+      label: "window.chrome missing on a Chrome user agent",
+      matched: /Chrome\/\d+/.test(ua) && !window.chrome,
+      value: `window.chrome: ${typeof window.chrome}`,
+    },
+    {
+      id: "zeroOuterSize",
+      label: "Window reports no outer dimensions",
+      matched: window.outerWidth === 0 || window.outerHeight === 0,
+      value: `${window.outerWidth} x ${window.outerHeight}`,
+    },
+    {
+      id: "defaultHeadlessScreen",
+      label: "Screen matches the headless default size",
+      matched:
+        window.screen.width === HEADLESS_DEFAULT_SCREEN.width &&
+        window.screen.height === HEADLESS_DEFAULT_SCREEN.height,
+      value: `${window.screen.width} x ${window.screen.height}`,
+    },
+    {
+      id: "softwareRenderer",
+      label: "WebGL is backed by a software renderer",
+      matched: SOFTWARE_RENDERER.test(renderer),
+      value: renderer || "Unavailable",
+    },
+    {
+      id: "noMediaDevices",
+      label: "No media devices are exposed",
+      matched: mediaDeviceCount === 0,
+      value: mediaDeviceCount === null ? "Unavailable" : String(mediaDeviceCount),
+    },
+    {
+      id: "emptyPlugins",
+      label: "Plugin list is empty",
+      matched: navigator.plugins.length === 0,
+      value: String(navigator.plugins.length),
+    },
+    {
+      id: "notificationMismatch",
+      label: "Notification permission disagrees with the Permissions API",
+      matched:
+        notificationPermission === "denied" && notificationPermissionState === "prompt",
+      value: `${notificationPermission ?? "Unavailable"} / ${notificationPermissionState ?? "Unavailable"
+        }`,
+    },
+  ];
+
+  const matched = signals.filter((signal) => signal.matched);
+  const uaToken = signals.find((signal) => signal.id === "uaHeadlessToken");
+
+  let verdict;
+  if (uaToken.matched) {
+    verdict = {
+      state: "on",
+      confidence: "high",
+      reason: "The user agent identifies a headless browser build.",
+    };
+  } else if (matched.length >= 2) {
+    verdict = {
+      state: "likely-on",
+      confidence: "medium",
+      reason: `${matched.length} headless signals matched: ${matched
+        .map((signal) => signal.id)
+        .join(", ")}.`,
+    };
+  } else if (matched.length === 1) {
+    verdict = {
+      state: "inconclusive",
+      confidence: "low",
+      reason: `Only ${matched[0].id} matched, which also happens on regular browsers.`,
+    };
+  } else {
+    verdict = {
+      state: "off",
+      confidence: "medium",
+      reason: "No headless signal matched.",
+    };
+  }
+
+  return { signals, verdict };
+};
+
+/**
+ * WebDriver only tells whether the page is being driven by automation. A
+ * visible browser under Selenium/testRigor sets it, and a plain headless
+ * browser started without automation flags does not, so it is reported on its
+ * own rather than folded into the headless verdict.
+ */
+export const detectAutomation = () => {
+  const webdriver = navigator.webdriver === true;
+  return {
+    webdriver,
+    verdict: {
+      state: webdriver ? "on" : "off",
+      confidence: "high",
+      reason: webdriver
+        ? "navigator.webdriver is true, so this page is being driven by automation."
+        : "navigator.webdriver is false.",
+    },
+  };
+};
+
+export const VERDICT_LABELS = {
+  on: "On",
+  "likely-on": "Likely on",
+  off: "Off",
+  inconclusive: "Inconclusive",
+  unknown: "Unknown",
+  unsupported: "Not detectable in this browser",
+};
+
+export const verdictLabel = (verdict) =>
+  verdict ? VERDICT_LABELS[verdict.state] ?? verdict.state : "Detecting…";


### PR DESCRIPTION
## Problem

Both detectors on `/osBrowser` returned the wrong answer in every Chrome configuration measured (Chrome 151, macOS):

- **Incognito** compared `storage.estimate().quota` against 100 GB, but Chrome caps a *normal* window at exactly 10 GiB and hands 2 GiB to private windows. Every Chrome window read as "Incognito: On".
- **Headless** treated `navigator.webdriver` as headless. That flag reports *automation*: a visible browser under Selenium/testRigor sets it (false positive on every testRigor run with a visible window), and a plain headless browser does not (false negative).
- The incognito verdict was published on mount with `quota` still `null`, so a test reading the card right after load got a stale "Off". If `estimate()` failed, the effect never re-ran and the stale verdict stuck.
- The Chromium guard required `browserFamily === "Chrome (Chromium)"`, so Edge/Brave InPrivate always read "Off"; Firefox and Safari reported a false "Off" instead of an unsupported state.
- The `webkitRequestFileSystem` probe was dead weight — it returns `success` in incognito too since Chrome 76.

## Changes

- New `src/utils/environmentDetection.js`. Every detector returns `{ state, confidence, reason }` instead of a boolean: `on` / `likely-on` / `off` / `inconclusive` / `unknown` / `unsupported`.
- **Incognito**: threshold recalibrated to the 2.5 GiB private-mode ceiling. An exact power-of-two quota (the fixed private allowance) yields high confidence; a low but non-fixed quota yields `Likely on` with low confidence, since an almost full disk cannot be ruled out. Covers the whole Chromium family; Firefox uses Service Worker availability (guarded by `isSecureContext`); Safari reports unsupported.
- **Headless**: eight independent signals, each rendered with the raw value that produced it. The UA headless token is decisive; otherwise ≥2 matches → `Likely on`, 1 → `Inconclusive`, 0 → `Off`.
- **Automation (WebDriver)** is now its own card, since that is what `navigator.webdriver` actually measures.
- A single async effect publishes verdicts only after the measurement lands, removing the race.
- Async readers time out after 1.5 s — `enumerateDevices()` was measured never settling in headless Chrome, which would freeze the verdict at "Detecting…".
- Stable `data-testid` hooks (`incognito-status`, `headless-confidence`, `headless-signal-<id>-matched`, `storage-quota-bytes`, …) and the quota shown both formatted and in raw bytes.

## Verification

End-to-end on the built app (`vite preview`), reading the rendered cards — headless runs via `--dump-dom`, visible windows via CDP:

| Scenario | Automation | Headless | Incognito | Quota |
|---|---|---|---|---|
| `--headless=new` | Off | **On** (high) | **Off** (high) | 10 GiB |
| headed normal | Off | Off | Off | 10 GiB |
| headed **incognito** | Off | Off | **On** (high) | **2 GiB** |
| headed + `--enable-automation` | **On** | **Off** | Off | 10 GiB |
| headless + spoofed UA | Off | Inconclusive (low) | Off | 10 GiB |

Before this change, the first three rows all reported "Incognito: On" and the last row reported "Headless: On".

## Notes for the reviewer

- The 2 GiB / 10 GiB constants were calibrated on Chrome 151 / macOS only. Worth confirming on Windows and Linux, where a normal-mode quota may be 60% of free disk rather than the 10 GiB cap — the power-of-two check is what keeps a small-disk runner from reading as incognito.
- The Firefox and Safari branches were not verified empirically (only Chrome and Safari are installed on the machine used, and Safari takes the `unsupported` branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)