### PR TITLE
Stop reporting a visible browser as headless

### DIFF
--- a/src/pages/osBrowser.jsx
+++ b/src/pages/osBrowser.jsx
@@ -153,7 +153,7 @@ const OsBrowser = () => {
       const signals = buildHeadlessSignals(probe);
       const { hints, verdict: runnerVerdict } = detectRunnerEnvironment(probe, signals);
       setHeadlessSignals(signals);
-      setHeadless(detectHeadless(signals));
+      setHeadless(detectHeadless(signals, runnerVerdict));
       setRunnerHints(hints);
       setRunner(runnerVerdict);
       setDetails(environmentDetails(probe));

--- a/src/utils/environmentDetection.js
+++ b/src/utils/environmentDetection.js
@@ -387,14 +387,21 @@ export const buildHeadlessSignals = (probe) => [
     value: `${probe.screenWidth} x ${probe.screenHeight}`,
   },
   {
-    // Headless Chrome keeps reporting its default screen while honouring
-    // --window-size, so the window ends up larger than the screen it lives on,
-    // which a real desktop cannot do. A window spanning two displays can.
-    id: "windowExceedsScreen",
-    label: "Window is larger than the reported screen",
+    // Headless Chrome keeps reporting its 800x600 default screen while honouring
+    // --window-size, so the page ends up bigger than the screen it lives on.
+    //
+    // This compares the VIEWPORT, not the outer window. The outer window is the
+    // viewport plus the browser's own decorations, so on a window that fills the
+    // screen the outer size legitimately exceeds it — measured at 1288x805 outer
+    // against a 1280x720 screen on a perfectly visible Chrome 149, which is what
+    // the outer-based version of this signal reported as headless. The viewport
+    // lives inside the window, which lives on the screen, so a viewport larger
+    // than the screen has no innocent explanation.
+    id: "viewportExceedsScreen",
+    label: "Viewport is larger than the reported screen",
     tier: "window",
-    matched: probe.outerWidth > probe.screenWidth || probe.outerHeight > probe.screenHeight,
-    value: `window ${probe.outerWidth} x ${probe.outerHeight} vs screen ${probe.screenWidth} x ${probe.screenHeight}`,
+    matched: probe.innerWidth > probe.screenWidth || probe.innerHeight > probe.screenHeight,
+    value: `viewport ${probe.innerWidth} x ${probe.innerHeight} vs screen ${probe.screenWidth} x ${probe.screenHeight}`,
   },
   {
     id: "softwareRenderer",
@@ -439,10 +446,21 @@ export const buildHeadlessSignals = (probe) => [
 
 const listIds = (signals) => signals.map((signal) => signal.id).join(", ");
 
-export const detectHeadless = (signals) => {
+/**
+ * `runnerVerdict` comes from detectRunnerEnvironment and only decides what an
+ * ABSENCE of window signals means. A modern `--headless=new` Chrome is
+ * deliberately indistinguishable from a headed one — plugin count, PDF viewer,
+ * window.chrome and chrome.loadTimes were all measured identical on Chrome 149 —
+ * so once the user agent is masked, the only place a headless browser can still
+ * be hiding is an automation runner. On a plain desktop the same absence of
+ * signals is simply a normal browser, and reporting that as "inconclusive" made
+ * every ordinary visitor look suspicious.
+ */
+export const detectHeadless = (signals, runnerVerdict) => {
   const windowSignals = signals.filter((s) => s.tier === "window" && s.matched);
   const environmentSignals = signals.filter((s) => s.tier === "environment" && s.matched);
   const uaToken = signals.find((signal) => signal.id === "uaHeadlessToken");
+  const onRunner = runnerVerdict?.state === "on" || runnerVerdict?.state === "likely-on";
 
   if (uaToken.matched) {
     return {
@@ -470,20 +488,23 @@ export const detectHeadless = (signals) => {
     };
   }
 
-  if (environmentSignals.length > 0) {
+  if (onRunner) {
     return {
       state: "inconclusive",
       confidence: "low",
-      reason: `No window-level signal matched. Only environment signals did (${listIds(
-        environmentSignals
-      )}), and a visible browser on a GPU-less cloud runner such as testRigor produces exactly the same values.`,
+      reason: `No window-level signal matched, but this looks like an automation runner${environmentSignals.length ? ` (${listIds(environmentSignals)})` : ""
+        }. A headless browser whose user agent has been masked cannot be ruled out here, because a modern headless Chrome is otherwise identical to a headed one.`,
     };
   }
 
   return {
     state: "off",
-    confidence: "medium",
-    reason: "No headless signal matched.",
+    confidence: environmentSignals.length > 0 ? "low" : "medium",
+    reason: environmentSignals.length
+      ? `No window-level signal matched. ${listIds(
+        environmentSignals
+      )} did, but those describe the machine rather than the window, and this does not look like an automation runner.`
+      : "No headless signal matched.",
   };
 };
 


### PR DESCRIPTION
The headless verdict on the **OS & Browser** page read `Likely on` for a perfectly visible Chrome 149. Two separate defects, both found by running the page against a matrix of browser configurations rather than by reading the code.

## 1. `windowExceedsScreen` compared the wrong rectangle

The signal's premise was "a window cannot be larger than the screen it sits on". That premise is false for a mundane reason: the **outer** window is the viewport *plus the browser's own decorations*, so a window filling the screen overflows it by the height of the toolbar.

Measured on a visible browser: **outer `1288x805` against a `1280x720` screen**. One matched window-level signal is enough to carry the verdict, so this alone produced `Likely on`.

The signal now compares the **viewport**, which lives inside the window, which lives on the screen — so it has no innocent way to exceed it. Renamed to `viewportExceedsScreen`.

It still catches the case it was written for: `--headless=new` keeps reporting its `800x600` default screen while honouring `--window-size`, measured at a `1400x813` viewport on an `800x600` screen.

## 2. Any environment signal forced "Inconclusive"

An ordinary desktop with an auto-hiding dock matches `noReservedScreenArea`, which was enough to downgrade the verdict — so a normal visitor's browser read as suspicious.

The absence of window-level signals is now resolved by the runner verdict. On an automation runner it stays `Inconclusive`, because that is the one place a headless browser with a masked user agent can still be hiding. Everywhere else it reports `Off`.

This is what the tiering in 910c8c0 was reaching for; it just needed the runner verdict, which is computed one line earlier at the call site.

## Results

| Configuration | Before | After |
|---|---|---|
| headless shell | `On` (High) | `On` (High) |
| `--headless=new` | `On` (High) | `On` (High) |
| `--headless=new --window-size` | `On` (High) | `On` (High) |
| headed, driven by automation | **`Likely on`** ❌ | `Inconclusive` (Low) |
| headed + swiftshader | **`Likely on`** ❌ | `Inconclusive` (Low) |
| headed, not driven (real user) | `Inconclusive` ❌ | **`Off`** |
| headless, user agent masked | `Inconclusive` | `Inconclusive` |

Verified against the built app, not the dev server. 5/5 acceptance cases pass.

## Negative result worth keeping

Twelve candidate signals were measured across the same matrix. **`pluginCount`, `pdfViewerEnabled`, `mimeTypes`, `window.chrome` and `chrome.loadTimes` are identical between `--headless=new` and headed Chrome 149.** Only the old headless shell differs on them, and it already announces itself in the user agent.

Modern headless is indistinguishable by design once the user agent is masked, so `Inconclusive` is the honest answer in that case rather than a signal still waiting to be found. This is recorded in the commit message so those signals do not get re-added as an apparent improvement.

## Still open

The hypothesis behind 910c8c0 was that a testRigor run showed `emptyPlugins` on a *visible* browser, which is why plugin count was demoted to the environment tier. These measurements say `emptyPlugins` only occurs on the old headless shell — so that run may have been genuinely headless with a masked user agent, and the verdict was right. Worth confirming with a paired headless/headed testRigor run against staging before deciding whether `emptyPlugins` belongs back in the window tier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)